### PR TITLE
Update rect.c

### DIFF
--- a/4-Get_Clippy/rect.c
+++ b/4-Get_Clippy/rect.c
@@ -47,7 +47,7 @@ List* Rect_split(Rect* subject_rect, Rect* cutting_rect) {
 
     //Begin splitting
     //1 -Split by left edge if that edge is between the subject's left and right edges 
-    if(cutting_rect->left >= subject_copy.left && cutting_rect->left <= subject_copy.right) {
+    if(cutting_rect->left > subject_copy.left && cutting_rect->left <= subject_copy.right) {
 
         //Try to make a new rectangle spanning from the subject rectangle's left and stopping before 
         //the cutting rectangle's left
@@ -68,7 +68,7 @@ List* Rect_split(Rect* subject_rect, Rect* cutting_rect) {
     }
 
     //2 -Split by top edge if that edge is between the subject's top and bottom edges 
-    if(cutting_rect->top >= subject_copy.top && cutting_rect->top <= subject_copy.bottom) {
+    if(cutting_rect->top > subject_copy.top && cutting_rect->top <= subject_copy.bottom) {
 
         //Try to make a new rectangle spanning from the subject rectangle's top and stopping before 
         //the cutting rectangle's top
@@ -96,7 +96,7 @@ List* Rect_split(Rect* subject_rect, Rect* cutting_rect) {
     }
 
     //3 -Split by right edge if that edge is between the subject's left and right edges 
-    if(cutting_rect->right >= subject_copy.left && cutting_rect->right <= subject_copy.right) {
+    if(cutting_rect->right >= subject_copy.left && cutting_rect->right < subject_copy.right) {
 
         //Try to make a new rectangle spanning from the subject rectangle's right and stopping before 
         //the cutting rectangle's right
@@ -123,7 +123,7 @@ List* Rect_split(Rect* subject_rect, Rect* cutting_rect) {
     }
 
     //4 -Split by bottom edge if that edge is between the subject's top and bottom edges 
-    if(cutting_rect->bottom >= subject_copy.top && cutting_rect->bottom <= subject_copy.bottom) {
+    if(cutting_rect->bottom >= subject_copy.top && cutting_rect->bottom < subject_copy.bottom) {
 
         //Try to make a new rectangle spanning from the subject rectangle's bottom and stopping before 
         //the cutting rectangle's bottom


### PR DESCRIPTION
Fixed an off by one error. Now if the two windows share an edge (example: top = 0) we don't create a rect outside of the window (with top = -1).
